### PR TITLE
add null privacy provider

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace report_completionoverview;
+namespace report_completionoverview\privacy;
 
 class provider implements
     // This plugin does not store any personal user data.

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,32 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace report_completionoverview;
+
+class provider implements
+    // This plugin does not store any personal user data.
+    \core_privacy\local\metadata\null_provider {
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason(): string {
+        return 'privacy:metadata';
+    }
+}

--- a/lang/en/report_completionoverview.php
+++ b/lang/en/report_completionoverview.php
@@ -40,4 +40,4 @@ $string['showbutton'] = 'Show courses';
 $string['noenrolments'] = 'Completion tracking is enabled but no students are enrolled on this course.';
 $string['nomodules'] = 'Completion tracking is enabled but no modules have been configured to track completion.';
 $string['courselink'] = 'view';
-
+$string['privacy:metadata'] = 'Completion overview does not store any of its own user data, only displays existing data'

--- a/lang/en/report_completionoverview.php
+++ b/lang/en/report_completionoverview.php
@@ -40,4 +40,4 @@ $string['showbutton'] = 'Show courses';
 $string['noenrolments'] = 'Completion tracking is enabled but no students are enrolled on this course.';
 $string['nomodules'] = 'Completion tracking is enabled but no modules have been configured to track completion.';
 $string['courselink'] = 'view';
-$string['privacy:metadata'] = 'Completion overview does not store any of its own user data, only displays existing data'
+$string['privacy:metadata'] = 'Completion overview does not store any of its own user data, only displays existing data';


### PR DESCRIPTION
The plugin does not store any of its own data, so adding a null privacy provider to pass unit tests in newer versions of Moodle